### PR TITLE
CI: omit fetching tag

### DIFF
--- a/.github/workflows/rpi-build.yml
+++ b/.github/workflows/rpi-build.yml
@@ -21,7 +21,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-          fetch-tags: true
       - uses: uraimo/run-on-arch-action@v2
         name: Run commands
         id: runcmd


### PR DESCRIPTION
Otherwise we get the error:
Cannot fetch both <hash> and res/tags/<tag> to refs/tags/<tag>.