### PR TITLE
camera-manager: improve CLI args

### DIFF
--- a/camera-manager/siyi_camera.hpp
+++ b/camera-manager/siyi_camera.hpp
@@ -37,15 +37,13 @@ public:
 
     void print_stream_settings()
     {
-        std::cout << "---\n"
-                  << "Stream settings: \n"
+        std::cout << "Stream settings: \n"
                   << _stream_settings;
     }
 
     void print_version()
     {
-        std::cout << "---\n"
-                  << _version;
+        std::cout << _version;
     }
 
     enum class Codec {

--- a/camera-manager/siyi_cli.cpp
+++ b/camera-manager/siyi_cli.cpp
@@ -1,14 +1,35 @@
 #include "siyi_camera.hpp"
 #include <iostream>
+#include <string_view>
+
+void print_usage(const std::string_view& bin_name)
+{
+    std::cout << "Usage: " << bin_name << " action [option]\n"
+              << "Actions:\n\n"
+              << "  help                     Show this help\n\n"
+              << "  version                  Show camera and gimbal version\n\n"
+              << "  take_picture             Take a picture to SD card\n\n"
+              << "  toggle_recording         Toggle start/stop video recording to SD card\n\n"
+              << "  gimbal_forward           Set gimbal forward\n\n"
+              << "  get_settings             Show all stream settings\n\n"
+              << "  set_resolution <option>  Set stream resolution\n\n"
+              << "    Options:\n"
+              << "      - 720  (for 1280x720)\n"
+              << "      - 1080 (for 1920x1080)\n\n"
+              << "  set_bitrate <option>     Set stream bitrate\n"
+              << "    Options:\n"
+              << "      - 1m (for 1.5 Mbps, only available at 1280x720)\n"
+              << "      - 2m (for 2 Mbps)\n"
+              << "      - 3m (for 3 Mbps)\n"
+              << "      - 4m (for 4 Mbps)\n\n"
+              << "  set_codec <option>         Set stream bitrate\n"
+              << "    Options:\n"
+              << "      - h264 (for H264)\n"
+              << "      - h265 (for H265/HVEC)\n";
+}
 
 int main(int argc, char* argv[])
 {
-    if (argc != 2) {
-        std::cerr << "Invalid argument\n";
-        return 1;
-    }
-
-    // SIYI setup second
     siyi::Messager siyi_messager;
     siyi_messager.setup("192.168.144.25", 37260);
 
@@ -22,111 +43,157 @@ int main(int argc, char* argv[])
         return 1;
     }
 
-    siyi_camera.print_version();
-    siyi_camera.print_stream_settings();
-    std::cout << "---\n";
+    if (argc == 1 ) {
+        std::cout << "No argument supplied.\n";
+        print_usage(argv[0]);
+        return 0;
+    }
 
-    const std::string action{argv[1]};
+    const std::string_view action{argv[1]};
 
-    if (action == "take_picture") {
+    if (action == "help") {
+        print_usage(argv[0]);
+
+    } else if (action == "version") {
+        siyi_camera.print_version();
+
+    } else if (action == "take_picture") {
+        std::cout << "Take picture\n";
         siyi_messager.send(siyi_serializer.assemble_message(siyi::TakePicture{}));
         (void)siyi_messager.receive();
-        std::cout << "Took picture\n";
 
     } else if (action == "toggle_recording") {
+        std::cout << "Toggle recording\n";
         siyi_messager.send(siyi_serializer.assemble_message(siyi::ToggleRecording{}));
         (void)siyi_messager.receive();
-        std::cout << "Toggled recording\n";
-
-    } else if (action == "stream_1080") {
-        std::cout << "Set resolution to 1920x1080..." << std::flush;
-        if (siyi_camera.set_resolution(siyi::Camera::Resolution::Res1920x1080)) {
-            std::cout << "ok" << std::endl;
-        } else {
-            std::cout << "failed" << std::endl;
-            return 1;
-        }
-
-    } else if (action == "stream_720") {
-        std::cout << "Set resolution to 1280x720..." << std::flush;
-        if (siyi_camera.set_resolution(siyi::Camera::Resolution::Res1280x720)) {
-            std::cout << "ok" << std::endl;
-        } else {
-            std::cout << "failed" << std::endl;
-            return 1;
-        }
-
-    } else if (action == "codec_h264") {
-        std::cout << "Set codec to H264..." << std::flush;
-        if (siyi_camera.set_codec(siyi::Camera::Codec::H264)) {
-            std::cout << "ok" << std::endl;
-        } else {
-            std::cout << "failed" << std::endl;
-            return 1;
-        }
-
-    } else if (action == "codec_h265") {
-        std::cout << "Set codec to H265..." << std::flush;
-        if (siyi_camera.set_codec(siyi::Camera::Codec::H265)) {
-            std::cout << "ok" << std::endl;
-        } else {
-            std::cout << "failed" << std::endl;
-            return 1;
-        }
-
-    } else if (action == "bitrate_4m") {
-        std::cout << "Set bitrate to 4 Mbps..." << std::flush;
-        if (siyi_camera.set_bitrate(4000)) {
-            std::cout << "ok" << std::endl;
-        } else {
-            std::cout << "failed" << std::endl;
-            return 1;
-        }
-
-    } else if (action == "bitrate_3m") {
-        std::cout << "Set bitrate to 3 Mbps..." << std::flush;
-        if (siyi_camera.set_bitrate(3000)) {
-            std::cout << "ok" << std::endl;
-        } else {
-            std::cout << "failed" << std::endl;
-            return 1;
-        }
-
-    } else if (action == "bitrate_2m") {
-        std::cout << "Set bitrate to 2 Mbps..." << std::flush;
-        if (siyi_camera.set_bitrate(2000)) {
-            std::cout << "ok" << std::endl;
-        } else {
-            std::cout << "failed" << std::endl;
-            return 1;
-        }
-
-    } else if (action == "bitrate_1m") {
-        std::cout << "Set bitrate to 1 Mbps..." << std::flush;
-        if (siyi_camera.set_bitrate(1000)) {
-            std::cout << "ok" << std::endl;
-        } else {
-            std::cout << "failed" << std::endl;
-            return 1;
-        }
-
-
-    } else if (action == "stream_settings") {
-        siyi_messager.send(siyi_serializer.assemble_message(siyi::StreamSettings{}));
-        (void)siyi_messager.receive();
-        std::cout << "Requested stream settings\n";
 
     } else if (action == "gimbal_forward") {
+        std::cout << "Set gimbal forward\n";
         siyi_messager.send(siyi_serializer.assemble_message(siyi::GimbalCenter{}));
         (void)siyi_messager.receive();
-        std::cout << "Set gimbal forward\n";
+
+    } else if (action == "get_settings") {
+        siyi_camera.print_stream_settings();
+
+    } else if (action == "set_resolution") {
+        if (argc >= 3) {
+            const std::string_view option{argv[2]};
+            if (option == "1080") {
+                std::cout << "Set resolution to 1920x1080..." << std::flush;
+                if (siyi_camera.set_resolution(siyi::Camera::Resolution::Res1920x1080)) {
+                    std::cout << "ok" << std::endl;
+                } else {
+                    std::cout << "failed" << std::endl;
+                    return 1;
+                }
+            } else if (option == "720") {
+                std::cout << "Set resolution to 1280x720..." << std::flush;
+                if (siyi_camera.set_resolution(siyi::Camera::Resolution::Res1280x720)) {
+                    std::cout << "ok" << std::endl;
+                } else {
+                    std::cout << "failed" << std::endl;
+                    return 1;
+                }
+            } else {
+                std::cout << "Invalid resolution" << std::endl;
+                print_usage(argv[0]);
+                return 1;
+            }
+
+            std::cout << "New settings:\n";
+            siyi_camera.print_stream_settings();
+
+        } else {
+            std::cout << "Not enough arguments\n";
+            print_usage(argv[0]);
+            return 1;
+        }
+
+    } else if (action == "set_bitrate") {
+        if (argc >= 3) {
+            const std::string_view option{argv[2]};
+            if (option == "1m") {
+                std::cout << "Set bitrate to 1.5 Mbps..." << std::flush;
+                if (siyi_camera.set_bitrate(1500)) {
+                    std::cout << "ok" << std::endl;
+                } else {
+                    std::cout << "failed" << std::endl;
+                    return 1;
+                }
+            } else if (option == "2m") {
+                std::cout << "Set bitrate to 2 Mbps..." << std::flush;
+                if (siyi_camera.set_bitrate(2000)) {
+                    std::cout << "ok" << std::endl;
+                } else {
+                    std::cout << "failed" << std::endl;
+                    return 1;
+                }
+            } else if (option == "3m") {
+                std::cout << "Set bitrate to 3 Mbps..." << std::flush;
+                if (siyi_camera.set_bitrate(3000)) {
+                    std::cout << "ok" << std::endl;
+                } else {
+                    std::cout << "failed" << std::endl;
+                    return 1;
+                }
+            } else if (option == "4m") {
+                std::cout << "Set bitrate to 4 Mbps..." << std::flush;
+                if (siyi_camera.set_bitrate(4000)) {
+                    std::cout << "ok" << std::endl;
+                } else {
+                    std::cout << "failed" << std::endl;
+                    return 1;
+                }
+            } else {
+                std::cout << "Invalid bitrate" << std::endl;
+                print_usage(argv[0]);
+                return 1;
+            }
+
+            std::cout << "New settings:\n";
+            siyi_camera.print_stream_settings();
+
+        } else {
+            std::cout << "Not enough arguments\n";
+            print_usage(argv[0]);
+            return 1;
+        }
+
+    } else if (action == "set_codec") {
+        if (argc >= 3) {
+            const std::string_view option{argv[2]};
+            if (option == "h264") {
+                std::cout << "Set codec to H264..." << std::flush;
+                if (siyi_camera.set_codec(siyi::Camera::Codec::H264)) {
+                    std::cout << "ok, power cycle camera now!" << std::endl;
+                } else {
+                    std::cout << "failed" << std::endl;
+                    return 1;
+                }
+            } else if (option == "h265") {
+                std::cout << "Set codec to H265 Mbps..." << std::flush;
+                if (siyi_camera.set_codec(siyi::Camera::Codec::H265)) {
+                    std::cout << "ok, power cycle camera now!" << std::endl;
+                } else {
+                    std::cout << "failed" << std::endl;
+                    return 1;
+                }
+            } else {
+                std::cout << "Invalid codec" << std::endl;
+                print_usage(argv[0]);
+                return 1;
+            }
+        } else {
+            std::cout << "Not enough arguments\n";
+            print_usage(argv[0]);
+            return 1;
+        }
 
     } else {
         std::cerr << "Unknown command\n";
+        print_usage(argv[0]);
         return 2;
     }
-
-    siyi_camera.print_stream_settings();
 
     return 0;
 }

--- a/camera-manager/siyi_protocol.hpp
+++ b/camera-manager/siyi_protocol.hpp
@@ -310,9 +310,9 @@ public:
     }
 
     friend std::ostream& operator<<(std::ostream& str, const AckGetStreamResolution& self) {
-        str << "VideoEncType: " << (self.video_enc_type == 1 ? "H264" : "H265") << '\n'
-            << "Resolution: " << self.resolution_l << "x" << self.resolution_h << '\n'
-            << "Bitrate: " << self.video_bitrate_kbps << " kbps\n";
+        str << "Resolution: " << self.resolution_l << "x" << self.resolution_h << '\n'
+            << "Bitrate: " << self.video_bitrate_kbps << " kbps\n"
+            << "Codec: " << (self.video_enc_type == 1 ? "H264" : "H265") << '\n';
         return str;
     }
 


### PR DESCRIPTION
This looks a little nicer now:

```
Usage: build/camera-manager/siyi_cli action [option]
Actions:

  help                     Show this help

  version                  Show camera and gimbal version

  take_picture             Take a picture to SD card

  toggle_recording         Toggle start/stop video recording to SD card

  gimbal_forward           Set gimbal forward

  get_settings             Show all stream settings

  set_resolution <option>  Set stream resolution

    Options:
      - 720  (for 1280x720)
      - 1080 (for 1920x1080)

  set_bitrate <option>     Set stream bitrate
    Options:
      - 1m (for 1.5 Mbps, only available at 1280x720)
      - 2m (for 2 Mbps)
      - 3m (for 3 Mbps)
      - 4m (for 4 Mbps)

  set_codec <option>         Set stream bitrate
    Options:
      - h264 (for H264)
      - h265 (for H265/HVEC)

```