### PR TITLE
rtsp-rebroadcast: add argument to choose codec

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,11 +132,21 @@ cmake --build build
 
 ### Run
 
-Then run it:
+Then run it with the codec argument:
 
 ```
-build/rtsp_rebroadcast
+build/rtsp_rebroadcast --codec h264
 ```
+or
+```
+build/rtsp_rebroadcast --codec h265
+```
+
+Use `--help` to see usage information:
+```
+build/rtsp_rebroadcast --help
+```
+
 (by default there is no output)
 
 To test the RTSP server, try to connect to it from another computer connected to the same network. Replace `192.168.x.y` with the IP of your RPI device.
@@ -283,5 +293,5 @@ This could have a couple of reasons:
 
 - Are both processes running, the rtsp-rebroadcast as well as the camera-manager?
 - Are all arguments to camera-manager correct?
-- Is everything H265 or H264? The rtsp_rebroadcast has H265 hard-coded, so the setting would have to match it.
+- Is everything H265 or H264? The rtsp_rebroadcast codec setting should match the camera's encoding format.
   Note that the camera's RTSP path is always `main.264` even if it is set to H265.

--- a/rtsp-rebroadcast/rtsp_rebroadcast.cpp
+++ b/rtsp-rebroadcast/rtsp_rebroadcast.cpp
@@ -1,6 +1,8 @@
 #include <gst/gst.h>
 #include <gst/rtsp-server/rtsp-server.h>
 #include <string>
+#include <iostream>
+#include <cstring>
 
 // RTSP re-broadcast using gstreamer.
 //
@@ -10,7 +12,47 @@
 // Source mostly taken from:
 // https://github.com/JonasVautherin/px4-gazebo-headless/tree/master/sitl_rtsp_proxy
 
+void print_usage(const char* program_name) {
+    std::cout << "Usage: " << program_name << " --codec <h264|h265> [options]\n";
+    std::cout << "Options:\n";
+    std::cout << "  --codec <h264|h265>  Video codec to use (required)\n";
+    std::cout << "  --help               Show this help message\n";
+}
+
 int main(int argc, char* argv[]) {
+    std::string codec;
+    bool codec_specified = false;
+
+    for (int i = 1; i < argc; i++) {
+        if (strcmp(argv[i], "--help") == 0) {
+            print_usage(argv[0]);
+            return 0;
+        } else if (strcmp(argv[i], "--codec") == 0) {
+            if (i + 1 < argc) {
+                codec = argv[i + 1];
+                if (codec != "h264" && codec != "h265") {
+                    std::cerr << "Error: Invalid codec '" << codec << "'. Use 'h264' or 'h265'.\n";
+                    return 1;
+                }
+                codec_specified = true;
+                i++;
+            } else {
+                std::cerr << "Error: --codec requires an argument\n";
+                return 1;
+            }
+        } else {
+            std::cerr << "Error: Unknown option '" << argv[i] << "'\n";
+            print_usage(argv[0]);
+            return 1;
+        }
+    }
+
+    if (!codec_specified) {
+        std::cerr << "Error: --codec argument is required\n";
+        print_usage(argv[0]);
+        return 1;
+    }
+
     gst_init(&argc, &argv);
 
     GMainLoop* main_loop = g_main_loop_new(NULL, false);
@@ -23,13 +65,24 @@ int main(int argc, char* argv[]) {
     GstRTSPServer* server = gst_rtsp_server_new();
     g_object_set(server, "service", "8554", NULL);
 
-    static constexpr auto launch_string =
-        "rtspsrc location=rtsp://192.168.144.25:8554/main.264 latency=0 "
-        "! rtph265depay "
-        "! rtph265pay name=pay0 pt=96";
+    std::string launch_string;
+    if (codec == "h264") {
+        launch_string =
+            "v4l2src device=/dev/video0 ! video/x-raw, format=I420, width=1024, height=576, framerate=30/1 "
+            "! x264enc"
+            "! rtph264pay name=pay0 pt=96";
+    } else if (codec == "h265") {
+        launch_string =
+            "v4l2src device=/dev/video0 ! video/x-raw, format=I420, width=1024, height=576, framerate=30/1 "
+            "! x265enc"
+            "! rtph265pay name=pay0 pt=97";
+    } else {
+        std::cerr << "Error: Unexpected codec value '" << codec << "'\n";
+        return 1;
+    }
 
     GstRTSPMediaFactory* factory = gst_rtsp_media_factory_new();
-    gst_rtsp_media_factory_set_launch(factory, launch_string);
+    gst_rtsp_media_factory_set_launch(factory, launch_string.c_str());
     gst_rtsp_media_factory_set_shared(factory, true);
 
     GstRTSPMountPoints* mount_points = gst_rtsp_server_get_mount_points(server);


### PR DESCRIPTION
This should make it less likely that the codec doesn't add up.

In the future, we should probably combine the two executables to be able to restart the rebroadcaster when the codec is changed via MAVLink.